### PR TITLE
fix: add support for ordering a connection by nullable edge fields

### DIFF
--- a/entgql/pagination.go
+++ b/entgql/pagination.go
@@ -197,6 +197,19 @@ func MultiCursorsPredicate[T any](after, before *Cursor[T], opts *MultiCursorsOp
 	return predicates, nil
 }
 
+// GetColumnNameForField gets the column name for the specified field and considers
+// non-ambiguous matching of terms that may be joined instead of a column on the table.
+func getColumnNameForField(s *sql.Selector, field string) string {
+	// The function is executed on query generation time.
+	column := s.C(field)
+	// If there is a non-ambiguous match, we use it. That is because
+	// some order terms may append joined information to query selection.
+	if matches := s.FindSelection(field); len(matches) == 1 {
+		column = matches[0]
+	}
+	return column
+}
+
 func multiPredicate[T any](cursor *Cursor[T], opts *MultiCursorsOptions) (func(*sql.Selector), error) {
 	values, ok := cursor.Value.([]any)
 	if !ok {
@@ -220,15 +233,50 @@ func multiPredicate[T any](cursor *Cursor[T], opts *MultiCursorsOptions) (func(*
 		// generated: (x < x1 OR (x = x1 AND y > y1) OR (x = x1 AND y = y1 AND id > last)).
 		var or []*sql.Predicate
 		for i := range opts.Fields {
+			value := values[i]
+			column := getColumnNameForField(s, opts.Fields[i])
+
+			// Helper function to add equality conditions for all previous fields
+			addPreviousFieldsConditions := func(predicates *[]*sql.Predicate) {
+				for j := 0; j < i; j++ {
+					prevColumn := getColumnNameForField(s, opts.Fields[j])
+					if values[j] == nil {
+						*predicates = append(*predicates, sql.IsNull(prevColumn))
+					} else {
+						*predicates = append(*predicates, sql.EQ(prevColumn, values[j]))
+					}
+				}
+			}
+
+			// Handle nil/NULL values in the cursor
+			if value == nil {
+				if opts.Directions[i] == OrderDirectionAsc {
+					// For ASC, NULL values come first, so the next page may have non-NULL values
+					or = append(or, sql.NotNull(column))
+				}
+				// For DESC, NULL values come last, no special handling needed
+				continue
+			}
+			// If the cursor value is not nil and we're sorting by DESC,
+			// we need to include NULL values in our results (as they come last in DESC order)
+			if opts.Directions[i] == OrderDirectionDesc {
+				var nullAnds []*sql.Predicate
+				nullAnds = append(nullAnds, sql.IsNull(column))
+				addPreviousFieldsConditions(&nullAnds)
+				or = append(or, sql.And(nullAnds...))
+			}
+
+			// Add standard comparison predicates for non-NULL values
 			var ands []*sql.Predicate
-			for j := 0; j < i; j++ {
-				ands = append(ands, sql.EQ(s.C(opts.Fields[j]), values[j]))
-			}
+			// Add condition for the current field based on its direction
 			if opts.Directions[i] == OrderDirectionAsc {
-				ands = append(ands, sql.GT(s.C(opts.Fields[i]), values[i]))
+				ands = append(ands, sql.GT(column, value))
 			} else {
-				ands = append(ands, sql.LT(s.C(opts.Fields[i]), values[i]))
+				ands = append(ands, sql.LT(column, value))
 			}
+
+			// Add equality conditions for all previous fields
+			addPreviousFieldsConditions(&ands)
 			or = append(or, sql.And(ands...))
 		}
 		s.Where(sql.Or(or...))


### PR DESCRIPTION
The generated SQL for cursor-based pagination was not properly considering that null values were possible in the field being used for ordering.

This fix works only for SQL databases that order NULLs first for ASC and last for DESC

https://github.com/ent/ent/issues/4059

**NOTE:** This shouldn't be merged into the upstream repository. These changes will only work for certain SQL dialects.